### PR TITLE
update ruamel API usage

### DIFF
--- a/src/duckietown_code_utils/yaml_pretty.py
+++ b/src/duckietown_code_utils/yaml_pretty.py
@@ -30,6 +30,7 @@ def yaml_load_plain(s: str):
 def yaml_dump(s) -> str:
     from ruamel.yaml import YAML
     from ruamel.yaml.compat import StringIO
+    # Ref: https://yaml.readthedocs.io/en/latest/example/#output-of-dump-as-a-string
 
     d = YAML(typ="rt")
     d.allow_unicode = False

--- a/src/duckietown_code_utils/yaml_pretty.py
+++ b/src/duckietown_code_utils/yaml_pretty.py
@@ -43,7 +43,6 @@ def yaml_dump_pretty(ob) -> str:
     from ruamel.yaml.compat import StringIO
 
     d = YAML(typ="rt")
-    d.allow_unicode = False
     stream = StringIO()
     d.dump(ob, stream)
     return stream.getvalue()

--- a/src/duckietown_code_utils/yaml_pretty.py
+++ b/src/duckietown_code_utils/yaml_pretty.py
@@ -4,37 +4,46 @@ from .type_checks import dt_check_isinstance
 
 def yaml_load(s: str):
     dt_check_isinstance("s", s, str)
-    from ruamel import yaml
+    from ruamel.yaml import YAML
 
     if s.startswith("..."):
         return None
     try:
-        l = yaml.load(s, Loader=yaml.RoundTripLoader)
+        l = YAML(typ="rt").load(s)
     except:
-        l = yaml.load(s, Loader=yaml.UnsafeLoader)
+        l = YAML(typ="unsafe").load(s)
 
-    return l
+    return dict(l)
 
 
 def yaml_load_plain(s: str):
     dt_check_isinstance("s", s, str)
-    from ruamel import yaml
+    from ruamel.yaml import YAML
 
     if s.startswith("..."):
         return None
-    l = yaml.load(s, Loader=yaml.UnsafeLoader)
+    l = YAML(typ="unsafe").load(s)
     # return remove_unicode(l)
-    return l
+    return dict(l)
 
 
 def yaml_dump(s) -> str:
-    from ruamel import yaml
+    from ruamel.yaml import YAML
+    from ruamel.yaml.compat import StringIO
 
-    res = yaml.dump(s, Dumper=yaml.RoundTripDumper, allow_unicode=False)
-    return res
+    d = YAML(typ="rt")
+    d.allow_unicode = False
+    stream = StringIO()
+    d.dump(s, stream)
+    return stream.getvalue()
 
 
 def yaml_dump_pretty(ob) -> str:
-    from ruamel import yaml
+    from ruamel.yaml import YAML
+    from ruamel.yaml.compat import StringIO
 
-    return yaml.dump(ob, Dumper=yaml.RoundTripDumper)
+    d = YAML(typ="rt")
+    d.allow_unicode = False
+    stream = StringIO()
+    d.dump(ob, stream)
+    return stream.getvalue()


### PR DESCRIPTION
Tested with simple data:

```
>>> from duckietown_code_utils import yaml_load, yaml_load_plain, yaml_dump, yaml_dump_pretty

>>> res = yaml_load("a: 1\nb: 2")
>>> type(res)
<class 'dict'>
>>> res
{'a': 1, 'b': 2}

>>> s = yaml_dump(res)
>>> type(s)
<class 'str'>
>>> s
'a: 1\nb: 2\n'

>>> res = yaml_load_plain("a: 1\nb: 2")
>>> type(res)
<class 'dict'>
>>> res
{'a': 1, 'b': 2}

>>> s = yaml_dump_pretty(res)
>>> type(s)
<class 'str'>
>>> s
'a: 1\nb: 2\n'
```

---

(Ref) Errors while running mooc LX:

```
{
	"name": "AttributeError",
	"message": "\n\"load()\" has been removed, use\n\n  yaml = YAML(typ='rt')\n  yaml.load(...)\n\nand register any classes that you use, or check the tag attribute on the loaded data,\ninstead of file \"/usr/local/lib/python3.8/dist-packages/duckietown_code_utils/yaml_pretty.py\", line 25\n\n    l = yaml.load(s, Loader=yaml.UnsafeLoader)\n\n",
	"stack": "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)\nCell \u001b[0;32mIn[14], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01msolution\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01msegments\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m detect_line_segments\n\u001b[1;32m      3\u001b[0m \u001b[38;5;66;03m# This function will take the image that we loaded, detect the line segments, and project them onto the ground plane. \u001b[39;00m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m# We don't need to worry too much about details here.\u001b[39;00m\n\u001b[1;32m      5\u001b[0m sg \u001b[38;5;241m=\u001b[39m detect_line_segments(img)\n\nFile \u001b[0;32m/code/state-estimation/packages/solution/segments.py:21\u001b[0m\n\u001b[1;32m     19\u001b[0m anti_instagram_name \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mbaseline\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m     20\u001b[0m robot_name \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mlab\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m---> 21\u001b[0m rcg \u001b[39m=\u001b[39m get_robot_camera_geometry(robot_name)\n\u001b[1;32m     24\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mdetect_line_segments\u001b[39m(img):\n\u001b[1;32m     25\u001b[0m     dtu\u001b[39m.\u001b[39mcheck_isinstance(img, np\u001b[39m.\u001b[39mndarray)\n\nFile \u001b[0;32m/code/catkin_ws/src/state-estimation/packages/dt-core/packages/complete_image_pipeline/include/image_processing/more_utils.py:17\u001b[0m, in \u001b[0;36mget_robot_camera_geometry\u001b[0;34m(robot_name)\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mget_robot_camera_geometry\u001b[39m(robot_name: \u001b[39mstr\u001b[39m) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m RobotCameraGeometry:\n\u001b[0;32m---> 17\u001b[0m     ci: CameraInfo \u001b[39m=\u001b[39m get_camera_info_for_robot(robot_name)\n\u001b[1;32m     18\u001b[0m     K \u001b[39m=\u001b[39m get_homography_for_robot(robot_name)\n\u001b[1;32m     20\u001b[0m     rectifier \u001b[39m=\u001b[39m Rectify(ci)\n\nFile \u001b[0;32m/code/catkin_ws/src/state-estimation/packages/dt-core/packages/complete_image_pipeline/include/image_processing/calibration_utils.py:224\u001b[0m, in \u001b[0;36mget_camera_info_for_robot\u001b[0;34m(robot_name)\u001b[0m\n\u001b[1;32m    220\u001b[0m     fn \u001b[39m=\u001b[39m get_camera_info_config_file(robot_name)\n\u001b[1;32m    222\u001b[0m     \u001b[39m# load the YAML\u001b[39;00m\n\u001b[0;32m--> 224\u001b[0m     calib_data \u001b[39m=\u001b[39m dtu\u001b[39m.\u001b[39;49myaml_load_file(fn, plain_yaml\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m)\n\u001b[1;32m    226\u001b[0m \u001b[39m# convert the YAML\u001b[39;00m\n\u001b[1;32m    227\u001b[0m \u001b[39mtry\u001b[39;00m:\n\nFile \u001b[0;32m/usr/local/lib/python3.8/dist-packages/duckietown_code_utils/yaml_wrap.py:50\u001b[0m, in \u001b[0;36myaml_load_file\u001b[0;34m(filename, plain_yaml)\u001b[0m\n\u001b[1;32m     48\u001b[0m \u001b[39mwith\u001b[39;00m \u001b[39mopen\u001b[39m(filename) \u001b[39mas\u001b[39;00m f:\n\u001b[1;32m     49\u001b[0m     contents \u001b[39m=\u001b[39m f\u001b[39m.\u001b[39mread()\n\u001b[0;32m---> 50\u001b[0m \u001b[39mreturn\u001b[39;00m interpret_yaml_file(filename, contents, f\u001b[39m=\u001b[39;49m\u001b[39mlambda\u001b[39;49;00m _filename, data: data, plain_yaml\u001b[39m=\u001b[39;49mplain_yaml)\n\nFile \u001b[0;32m/usr/local/lib/python3.8/dist-packages/duckietown_code_utils/yaml_wrap.py:73\u001b[0m, in \u001b[0;36minterpret_yaml_file\u001b[0;34m(filename, contents, f, plain_yaml)\u001b[0m\n\u001b[1;32m     71\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m     72\u001b[0m     \u001b[39mif\u001b[39;00m plain_yaml:\n\u001b[0;32m---> 73\u001b[0m         data \u001b[39m=\u001b[39m yaml_load_plain(contents)\n\u001b[1;32m     74\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[1;32m     75\u001b[0m         data \u001b[39m=\u001b[39m yaml_load(contents)\n\nFile \u001b[0;32m/usr/local/lib/python3.8/dist-packages/duckietown_code_utils/yaml_pretty.py:25\u001b[0m, in \u001b[0;36myaml_load_plain\u001b[0;34m(s)\u001b[0m\n\u001b[1;32m     23\u001b[0m \u001b[39mif\u001b[39;00m s\u001b[39m.\u001b[39mstartswith(\u001b[39m\"\u001b[39m\u001b[39m...\u001b[39m\u001b[39m\"\u001b[39m):\n\u001b[1;32m     24\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m---> 25\u001b[0m l \u001b[39m=\u001b[39m yaml\u001b[39m.\u001b[39;49mload(s, Loader\u001b[39m=\u001b[39;49myaml\u001b[39m.\u001b[39;49mUnsafeLoader)\n\u001b[1;32m     26\u001b[0m \u001b[39m# return remove_unicode(l)\u001b[39;00m\n\u001b[1;32m     27\u001b[0m \u001b[39mreturn\u001b[39;00m l\n\nFile \u001b[0;32m/usr/local/lib/python3.8/dist-packages/ruamel/yaml/main.py:1071\u001b[0m, in \u001b[0;36mload\u001b[0;34m(stream, Loader, version, preserve_quotes)\u001b[0m\n\u001b[1;32m   1064\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload\u001b[39m(\n\u001b[1;32m   1065\u001b[0m     stream: Any, Loader: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m, version: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m, preserve_quotes: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m   1066\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Any:\n\u001b[1;32m   1067\u001b[0m \u001b[39m    \u001b[39m\u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m   1068\u001b[0m \u001b[39m    Parse the first YAML document in a stream\u001b[39;00m\n\u001b[1;32m   1069\u001b[0m \u001b[39m    and produce the corresponding Python object.\u001b[39;00m\n\u001b[1;32m   1070\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 1071\u001b[0m     error_deprecation(\u001b[39m'\u001b[39;49m\u001b[39mload\u001b[39;49m\u001b[39m'\u001b[39;49m, \u001b[39m'\u001b[39;49m\u001b[39mload\u001b[39;49m\u001b[39m'\u001b[39;49m, arg\u001b[39m=\u001b[39;49m_error_dep_arg, comment\u001b[39m=\u001b[39;49m_error_dep_comment)\n\nFile \u001b[0;32m/usr/local/lib/python3.8/dist-packages/ruamel/yaml/main.py:1023\u001b[0m, in \u001b[0;36merror_deprecation\u001b[0;34m(fun, method, arg, comment)\u001b[0m\n\u001b[1;32m   1021\u001b[0m s \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m'\u001b[39m\n\u001b[1;32m   1022\u001b[0m \u001b[39mif\u001b[39;00m sys\u001b[39m.\u001b[39mversion_info \u001b[39m<\u001b[39m (\u001b[39m3\u001b[39m, \u001b[39m10\u001b[39m):\n\u001b[0;32m-> 1023\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m(s)\n\u001b[1;32m   1024\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m   1025\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m(s, name\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m)\n\n\u001b[0;31mAttributeError\u001b[0m: \n\"load()\" has been removed, use\n\n  yaml = YAML(typ='rt')\n  yaml.load(...)\n\nand register any classes that you use, or check the tag attribute on the loaded data,\ninstead of file \"/usr/local/lib/python3.8/dist-packages/duckietown_code_utils/yaml_pretty.py\", line 25\n\n    l = yaml.load(s, Loader=yaml.UnsafeLoader)\n\n"
}
```